### PR TITLE
Test Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ language: node_js
 node_js:
     - "10"
     - "12"
+env:
+  - PROM_CLIENT_VERSION="10"
+  - PROM_CLIENT_VERSION="11"
+  - PROM_CLIENT_VERSION="12"
 
 branches:
   only:
@@ -17,6 +21,10 @@ services:
 
 before_script:
   - sleep 10
+  - npm install prom-client@"$PROM_CLIENT_VERSION" # install specific prom-client version (a peer dependency)
+
+script:
+  - npm run test
 
 after_success:
   - ls -R1 coverage-report/lcov.info                                        # list the files (for debugging)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1116,7 +1116,8 @@
     "bintrees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
+      "dev": true
     },
     "blob": {
       "version": "0.0.5",
@@ -13904,6 +13905,7 @@
       "version": "11.5.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
       "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+      "dev": true,
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -16371,6 +16373,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
       "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dev": true,
       "requires": {
         "bintrees": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -93,11 +93,13 @@
     "debug": "^4.1.1",
     "moment": "^2.24.0",
     "path-to-regexp": "^6.1.0",
-    "prom-client": "^11.5.3",
     "qs": "^6.9.1",
     "request": "^2.88.0",
     "send": "^0.17.1",
     "uuid": "^3.4.0"
+  },
+  "peerDependencies": {
+    "prom-client": ">= 10 <= 12"
   },
   "devDependencies": {
     "swagger-stats-ux": "^0.95.22",
@@ -149,6 +151,7 @@
     "nyc": "^11.4.0",
     "phantomjs-prebuilt": "^2.1.16",
     "postcss-loader": "^2.0.9",
+    "prom-client": "^11.5.3",
     "q": "^1.5.1",
     "serve-favicon": "^2.4.5",
     "serve-static": "^1.13.1",


### PR DESCRIPTION
We use swagger-stats together with [prometheus-gc-stats](https://www.npmjs.com/package/prometheus-gc-stats). Currently swagger-stats defines prom-client as a **direct dependency** with version range "^11.5.3". prometheus-gc-stats has a **peer dependency** on prom-client with version range ">= 10 <= 12".

Because it's a peer dependency of prometheus-gc-stats and because we need to add some custom metrics, we must add a direct dependency on prom-client to our own code ("my-app"). This has version range "^12.0.0".

We end up with a dependency tree like this:
```
my-app/
  node_modules/
    prom-client@12.0.0/
    prometheus-gc-stats
    swagger-stats/
      node_modules/
        prom-client@11.5.3/
```
This means swagger-stats is using it's own copy of prom-client and we're not able (at least not easily) to return all metrics at once. The problem is that it's quite hard to find out what is going on here. Most people will just notice that they are missing some metrics.

One reason to workaround this would be to downgrade our version of prom-client to v11. Then we would end up with one single version of prom-client in the tree (because of hoisting) and everything would work. But this is a rather fragile solution because every developer has to know that we must not upgrade it. When there is a new release of swagger-stats with a new major version of prom-client we have to remember to also upgrade our version...

The solution to this would be for swagger-stats to add prom-client as a [peer dependency](https://nodejs.org/es/blog/npm/peer-dependencies/). Then the host package ("my-app") has to provide a compatible version of prom-client to swagger-stats. npm/yarn will make sure this exists and warn if not.

I can provide a pull request with the necessary changes. This change would require a major release I guess.